### PR TITLE
update protobuf-net to 2.4.1

### DIFF
--- a/src/StackExchange.Utils.Http/StackExchange.Utils.Http.csproj
+++ b/src/StackExchange.Utils.Http/StackExchange.Utils.Http.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Jil" Version="2.17.0" />
-    <PackageReference Include="protobuf-net" Version="2.3.7" />
+    <PackageReference Include="protobuf-net" Version="2.4.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
 
     <Compile Update="Extensions.*.cs" DependentUpon="Extensions.cs" />


### PR DESCRIPTION
.NET Core 3 moved some assemblies around, which causes some problems with features like `SkipConstructor`; this update fixes those issues