### PR TITLE
Add .WithClientPool() to allow replacing the client pool

### DIFF
--- a/src/StackExchange.Utils.Http/Extensions.Modifier.cs
+++ b/src/StackExchange.Utils.Http/Extensions.Modifier.cs
@@ -26,6 +26,18 @@ namespace StackExchange.Utils
         }
 
         /// <summary>
+        /// Sets an <see cref="IHttpClientPool"/> to get a client from for this request.
+        /// </summary>
+        /// <param name="builder">The builder we're working on.</param>
+        /// <param name="pool">The pool to use on this request (defaults to global settings otherwise).</param>
+        /// <returns>The request builder for chaining.</returns>
+        public static IRequestBuilder WithClientPool(this IRequestBuilder builder, IHttpClientPool pool)
+        {
+            builder.ClientPool = pool;
+            return builder;
+        }
+
+        /// <summary>
         /// Sets a timeout for this request.
         /// </summary>
         /// <param name="builder">The builder we're working on.</param>

--- a/src/StackExchange.Utils.Http/Http.cs
+++ b/src/StackExchange.Utils.Http/Http.cs
@@ -55,8 +55,10 @@ namespace StackExchange.Utils
                 using (settings.ProfileRequest?.Invoke(request))
                 using (request)
                 {
+                    // Get the pool
+                    var pool = builder.Inner.ClientPool ?? settings.ClientPool;
                     // Send the request
-                    using (response = await settings.ClientPool.Get(builder.Inner).SendAsync(request, cancellationToken))
+                    using (response = await pool.Get(builder.Inner).SendAsync(request, cancellationToken))
                     {
                         // If we haven't ignored it, throw and we'll log below
                         // This isn't ideal cntrol flow behavior, but it's the only way to get proper stacks

--- a/src/StackExchange.Utils.Http/HttpBuilder.cs
+++ b/src/StackExchange.Utils.Http/HttpBuilder.cs
@@ -15,6 +15,7 @@ namespace StackExchange.Utils
         public IEnumerable<HttpStatusCode> IgnoredResponseStatuses { get; set; } = Enumerable.Empty<HttpStatusCode>();
         public TimeSpan Timeout { get; set; }
         public IWebProxy Proxy { get; set; }
+        public IHttpClientPool ClientPool { get; set; }
         public event EventHandler<HttpExceptionArgs> BeforeExceptionLog;
         private readonly string _callerName, _callerFile;
         private readonly int _callerLine;

--- a/src/StackExchange.Utils.Http/IRequestBuilder.cs
+++ b/src/StackExchange.Utils.Http/IRequestBuilder.cs
@@ -48,6 +48,12 @@ namespace StackExchange.Utils
         IWebProxy Proxy { get; set; }
 
         /// <summary>
+        /// The <see cref="IHttpClientPool"/> to get a client from.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IHttpClientPool ClientPool { get; set; }
+
+        /// <summary>
         /// An before-logging event to call in case on an error.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/tests/StackExchange.Utils.Tests/HttpAlternativePoolTests.cs
+++ b/tests/StackExchange.Utils.Tests/HttpAlternativePoolTests.cs
@@ -1,0 +1,48 @@
+﻿using System.Net;
+using System.Net.Http;
+using Xunit;
+
+namespace StackExchange.Utils.Tests
+{
+    public class HttpAlternativePoolTests
+    {
+        [Fact]
+        public async System.Threading.Tasks.Task UseAlternativePool()
+        {
+            var customPool = new CountingPool(Http.DefaultSettings);
+            var request = Http.Request("https://httpbin.org/get")
+                              .WithClientPool(customPool);
+
+            Assert.Equal(customPool, request.ClientPool);
+
+            var result = await request.ExpectJson<HttpBinResponse>()
+                                      .GetAsync();
+
+            Assert.Equal(1, customPool.GetCount);
+            Assert.True(result.Success);
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.NotNull(result);
+            Assert.Equal("https://httpbin.org/get", result.Data.Url);
+            Assert.Equal(Http.DefaultSettings.UserAgent, result.Data.Headers["User-Agent"]);
+        }
+    }
+
+    public class CountingPool : IHttpClientPool
+    {
+        private DefaultHttpClientPool InnerPool { get; }
+        public int GetCount { get; private set; } = 0;
+
+        public CountingPool(HttpSettings settings)
+        {
+            InnerPool = new DefaultHttpClientPool(settings);
+        }
+
+        public HttpClient Get(IRequestBuilder builder)
+        {
+            GetCount++;
+            return InnerPool.Get(builder);
+        }
+
+        public void Clear() => InnerPool.Clear();
+    }
+}


### PR DESCRIPTION
Ideal for testing! This lets you specify your own pool per request, else we drop back to the defaults as happens today.