### PR TITLE
encoding forms as FormUrlEncodedContent has a size limitation

### DIFF
--- a/src/StackExchange.Utils.Http/Extensions.Send.cs
+++ b/src/StackExchange.Utils.Http/Extensions.Send.cs
@@ -29,9 +29,16 @@ namespace StackExchange.Utils
         /// <param name="builder">The builder we're working on.</param>
         /// <param name="form">The <see cref="NameValueCollection"/> (e.g. FormCollection) to use.</param>
         /// <returns>The request builder for chaining.</returns>
-        public static IRequestBuilder SendForm(this IRequestBuilder builder, NameValueCollection form) =>
-            SendContent(builder, new FormUrlEncodedContent(form.AllKeys.ToDictionary(k => k, v => form[v])));
-
+        public static IRequestBuilder SendForm(this IRequestBuilder builder, NameValueCollection form)
+        {
+            var content = new MultipartFormDataContent();
+            foreach(var formKey in form.AllKeys)
+            {                
+                content.Add(new StringContent(form[formKey]), formKey);
+            }
+            return SendContent(builder, content);
+        }
+            
         /// <summary>
         /// Adds raw HTML content as the body for this request.
         /// </summary>

--- a/tests/StackExchange.Utils.Tests/HttpTests.cs
+++ b/tests/StackExchange.Utils.Tests/HttpTests.cs
@@ -239,6 +239,9 @@ namespace StackExchange.Utils.Tests
 
             Assert.True(result.Success);
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.NotNull(result);
+            Assert.Equal("https://httpbin.org/post", result.Data.Url);
+            Assert.Equal(Http.DefaultSettings.UserAgent, result.Data.Headers["User-Agent"]);
         }
     }
 }

--- a/tests/StackExchange.Utils.Tests/HttpTests.cs
+++ b/tests/StackExchange.Utils.Tests/HttpTests.cs
@@ -220,5 +220,25 @@ namespace StackExchange.Utils.Tests
             Assert.Equal("https://httpbin.org/patch", result.Data.Url);
             Assert.Equal(Http.DefaultSettings.UserAgent, result.Data.Headers["User-Agent"]);
         }
+
+        [Fact]
+        public async Task LargePost()
+        {
+            // 5MB string
+            var myString = new string('*', 1048576 * 5);
+
+            var form = new System.Collections.Specialized.NameValueCollection
+            {                
+                ["requestsJson"] = myString
+            };
+
+            var result = await Http.Request("https://httpbin.org/post")
+                .SendForm(form)
+                .ExpectJson<HttpBinResponse>()
+                .PostAsync();
+
+            Assert.True(result.Success);
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
     }
 }


### PR DESCRIPTION
Previously using `FormUrlEncodedContent` would throw `Invalid URI: The Uri string is too long` if a form was larger than 2083 characters.   