### PR TITLE
Try to avoid an extra array alloc/copy in SendProtobuf

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "2.2.100"
+    "version": "2.2.100",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
   }
 }

--- a/src/StackExchange.Utils.Http/Extensions.Send.cs
+++ b/src/StackExchange.Utils.Http/Extensions.Send.cs
@@ -88,7 +88,9 @@ namespace StackExchange.Utils
             {
                 Serializer.Serialize(gzs, obj);
                 gzs.Close();
-                var protoContent = new ByteArrayContent(output.ToArray());
+                var protoContent = output.TryGetBuffer(out var segment)
+                    ? new ByteArrayContent(segment.Array, segment.Offset, segment.Count)
+                    : new ByteArrayContent(output.ToArray());
                 protoContent.Headers.Add("Content-Type", "application/x-www-form-urlencoded");
                 protoContent.Headers.Add("Content-Encoding", "gzip");
                 return SendContent(builder, protoContent);


### PR DESCRIPTION
- use `TryGetBuffer` and send the segment whenever possible (which is "always" in reality, I'm just being cautious)
- don't force old SDK