### PR TITLE
GitHub Actions support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build & Test
+
+on:
+  pull_request:
+    branches:
+    - master
+    paths-ignore:
+    - 'docs/**' # Don't run workflow when files are only in the /docs directory
+
+jobs:
+  build-ubuntu:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-dotnet@v1
+      with:
+          dotnet-version: '3.1.302'
+    - name: .NET Build
+      run: dotnet build Build.csproj -c Release --nologo /p:CI=true
+    - name: .NET Test
+      run: dotnet test Build.csproj -c Release --no-build --nologo /p:CI=true
+  build-windows:
+    runs-on: windows-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: .NET Build
+      run: dotnet build Build.csproj -c Release --nologo /p:CI=true
+    - name: .NET Test
+      run: dotnet test Build.csproj -c Release --no-build --nologo /p:CI=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - uses: actions/setup-dotnet@v1
+      with:
+          dotnet-version: '3.1.302'
     - name: .NET Build
       run: dotnet build Build.csproj -c Release --nologo /p:CI=true
     - name: .NET Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: actions/setup-dotnet@v1
-      with:
-          dotnet-version: '3.1.302'
     - name: .NET Build
       run: dotnet build Build.csproj -c Release --nologo /p:CI=true
     - name: .NET Test
@@ -31,9 +28,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: actions/setup-dotnet@v1
-      with:
-          dotnet-version: '3.1.302'
     - name: .NET Build
       run: dotnet build Build.csproj -c Release --nologo /p:CI=true
     - name: .NET Test

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -32,6 +32,9 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - uses: actions/setup-dotnet@v1
+      with:
+          dotnet-version: '3.1.302'
     - name: .NET Build
       run: dotnet build Build.csproj -c Release --nologo /p:CI=true
     - name: .NET Test

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -16,9 +16,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: actions/setup-dotnet@v1
-      with:
-          dotnet-version: '3.1.302'
     - name: .NET Build
       run: dotnet build Build.csproj -c Release --nologo /p:CI=true
     - name: .NET Test
@@ -32,9 +29,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: actions/setup-dotnet@v1
-      with:
-          dotnet-version: '3.1.302'
     - name: .NET Build
       run: dotnet build Build.csproj -c Release --nologo /p:CI=true
     - name: .NET Test

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,42 @@
+name: Build, Test & Package
+
+on:
+  push:
+    branches:
+    - master
+    paths-ignore:
+    - 'docs/**' # Don't run workflow when files are only in the /docs directory
+
+jobs:
+  build-ubuntu:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-dotnet@v1
+      with:
+          dotnet-version: '3.1.302'
+    - name: .NET Build
+      run: dotnet build Build.csproj -c Release --nologo /p:CI=true
+    - name: .NET Test
+      run: dotnet test Build.csproj -c Release --no-build --nologo /p:CI=true
+  build-windows:
+    needs: build-ubuntu
+    runs-on: windows-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: .NET Build
+      run: dotnet build Build.csproj -c Release --nologo /p:CI=true
+    - name: .NET Test
+      run: dotnet test Build.csproj -c Release --no-build --nologo /p:CI=true
+    - name: .NET Pack
+      run: dotnet pack Build.csproj --no-build -c Release --nologo /p:PackageOutputPath=${env:GITHUB_WORKSPACE}\.nupkgs /p:CI=true
+    - name: Push to MyGet
+      run: dotnet nuget push ${env:GITHUB_WORKSPACE}\.nupkgs\*.nupkg -s https://www.myget.org/F/stackoverflow/api/v2/package -k ${{ secrets.MYGET_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ obj
 *.suo
 *.user
 *.nupkgs
+.idea/*
 .vs/*
+.DS_Store

--- a/Build.csproj
+++ b/Build.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.Build.Traversal/2.0.24">
+  <ItemGroup>
+    <ProjectReference Include="src\**\*.csproj" />
+    <ProjectReference Include="samples\**\*.csproj" />
+    <ProjectReference Include="tests\**\*.csproj" />
+  </ItemGroup>
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.201",
+    "version": "3.1.302",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "3.1.302",
-    "rollForward": "latestMajor",
+    "version": "3.1.300",
+    "rollForward": "latestMinor",
     "allowPrerelease": false
   }
 }

--- a/src/StackExchange.Utils.Http/StackExchange.Utils.Http.csproj
+++ b/src/StackExchange.Utils.Http/StackExchange.Utils.Http.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Jil" Version="2.17.0" />
     <PackageReference Include="protobuf-net" Version="2.4.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" IncludeAssets="runtime;build;native;contentfiles;analyzers" />
 
     <Compile Update="Extensions.*.cs" DependentUpon="Extensions.cs" />
   </ItemGroup>

--- a/tests/StackExchange.Utils.Tests/StackExchange.Utils.Tests.csproj
+++ b/tests/StackExchange.Utils.Tests/StackExchange.Utils.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/StackExchange.Utils.Http/StackExchange.Utils.Http.csproj" />


### PR DESCRIPTION
This PR adds support for using GitHub Actions to build the project. It also adds `Build.csproj` which is a `Microsoft.Build.Traversal` used for building / testing / packaging everything and updates `global.json` to use .NET Core SDK 3.1.302.

There are two GH workflows - one for building and testing (run on every PR to master) and one for building, testing and packaging (used for publishing to MyGet).

## Tasks
 - [ ] Configure MyGet API key in secrets
 - [ ] Kill AppVeyor builds