### PR TITLE
Configuration: Fix `GetChildKeys` to work correctly in prefixed configuration provider

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,5 @@
 {
   "sdk": {
-    "version": "3.1.300",
-    "rollForward": "latestMinor",
     "allowPrerelease": false
   }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/src/StackExchange.Utils.Configuration/PrefixedConfigurationProvider.cs
+++ b/src/StackExchange.Utils.Configuration/PrefixedConfigurationProvider.cs
@@ -20,7 +20,7 @@ namespace StackExchange.Utils
 
         public override IEnumerable<string> GetChildKeys(IEnumerable<string> earlierKeys, string parentPath)
         {
-            if (parentPath != null && !parentPath.StartsWith(_prefix))
+            if (parentPath != null && !parentPath.StartsWith(_prefix, StringComparison.OrdinalIgnoreCase))
             {
                 return earlierKeys;
             }
@@ -52,7 +52,7 @@ namespace StackExchange.Utils
 
         public override void Set(string key, string value)
         {
-            if (!key.StartsWith(_prefixWithDelimiter) || key.Length == _prefixWithDelimiter.Length)
+            if (!key.StartsWith(_prefixWithDelimiter, StringComparison.OrdinalIgnoreCase) || key.Length == _prefixWithDelimiter.Length)
             {
                 return;
             }
@@ -62,7 +62,7 @@ namespace StackExchange.Utils
         
         public override bool TryGet(string key, out string value)
         {
-            if (!key.StartsWith(_prefixWithDelimiter) || key.Length == _prefixWithDelimiter.Length)
+            if (!key.StartsWith(_prefixWithDelimiter, StringComparison.OrdinalIgnoreCase) || key.Length == _prefixWithDelimiter.Length)
             {
                 value = null;
                 return false;


### PR DESCRIPTION
Prior to this commit `GetChildKeys` was using a naive implementation that did not function correctly when there were multiple `IConfigurationProvider` implementations chained to the prefixed configuration.

This commit updates the method to ensure that it
 - returns the prefix and earlier keys if the parent path is null
 - returns just the earlier keys if the parent path is not null and does not have the prefix
 - correctly passes the parent path *without* the prefix to the child configuration providers when the parent path is prefixed

It also adds a test to validate that the fixes are sane.

Finally, in a fun episode of Yak Shaving, this tweaks `global.json` and `Directory.Build.props` to ensure that the project can build - there's an issue with upgrading the latest stable VS to 16.8 that inadvertently (and incorrectly) nukes SDK directories and our global.json was preventing the use of the 5.0 SDK for build purposes. And then Nerdbank got angry so needed an upgrade too. Yay!