### PR TITLE
Allow logging error response body

### DIFF
--- a/src/StackExchange.Utils.Http/Extensions.Modifier.cs
+++ b/src/StackExchange.Utils.Http/Extensions.Modifier.cs
@@ -92,6 +92,18 @@ namespace StackExchange.Utils
         }
 
         /// <summary>
+        /// Logs error response body as part of the httpClientException data when the response's HTTP status code is any of the <paramref name="statusCodes"/>.
+        /// </summary>
+        /// <param name="builder">The builder we're working on.</param>
+        /// <param name="statusCodes">HTTP error status codes to log for.</param>
+        /// <returns>The request builder for chaining.</returns>
+        public static IRequestBuilder WithErrorResponseBodyLogging(this IRequestBuilder builder, params HttpStatusCode[] statusCodes)
+        {
+            builder.LogErrorResponseBodyStatuses = statusCodes;
+            return builder;
+        }
+
+        /// <summary>
         /// Adds an event handler for this request, for appending additional information to the logged exception for example.
         /// </summary>
         /// <param name="builder">The builder we're working on.</param>

--- a/src/StackExchange.Utils.Http/HttpBuilder.cs
+++ b/src/StackExchange.Utils.Http/HttpBuilder.cs
@@ -13,6 +13,7 @@ namespace StackExchange.Utils
         public HttpRequestMessage Message { get; }
         public bool LogErrors { get; set; } = true;
         public IEnumerable<HttpStatusCode> IgnoredResponseStatuses { get; set; } = Enumerable.Empty<HttpStatusCode>();
+        public IEnumerable<HttpStatusCode> LogErrorResponseBodyStatuses { get; set; } = Enumerable.Empty<HttpStatusCode>();
         public TimeSpan Timeout { get; set; }
         public IWebProxy Proxy { get; set; }
         public bool BufferResponse { get; set; } = true;

--- a/src/StackExchange.Utils.Http/IRequestBuilder.cs
+++ b/src/StackExchange.Utils.Http/IRequestBuilder.cs
@@ -30,6 +30,12 @@ namespace StackExchange.Utils
         bool LogErrors { get; set; }
 
         /// <summary>
+        /// Whether to log error response body on a given http status code.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IEnumerable<HttpStatusCode> LogErrorResponseBodyStatuses { get; set; }
+        
+        /// <summary>
         /// Which <see cref="HttpStatusCode"/>s to ignore as errors on responses.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/tests/StackExchange.Utils.Tests/HttpLogErrorResponseBodyTest.cs
+++ b/tests/StackExchange.Utils.Tests/HttpLogErrorResponseBodyTest.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Threading.Tasks;
+using HttpMock;
+using Xunit;
+
+namespace StackExchange.Utils.Tests
+{
+    public class HttpLogErrorResponseBodyTest
+    {
+        private readonly IHttpServer _stubHttp = HttpMockRepository.At("http://localhost:9191");
+
+        [Fact]
+        public async Task WithErrorResponseBodyLogging_IfStatusCodeMatchesTheGivenOne_IncludeResponseBodyInException()
+        {
+            const string errorResponseBody = "{'Foo': 'Bar'}";
+        	_stubHttp.Stub(x => x.Get("/some-endpoint"))
+        			.Return(errorResponseBody)
+        			.WithStatus(HttpStatusCode.UnprocessableEntity);
+
+            var response = await Http
+                .Request("http://localhost:9191/some-endpoint")
+                .WithErrorResponseBodyLogging(HttpStatusCode.UnprocessableEntity)
+                .ExpectString()
+                .GetAsync();
+
+            Assert.Equal(HttpStatusCode.UnprocessableEntity,response.StatusCode);
+            
+            var httpCallResponses = Assert.IsType<HttpCallResponse<string>>(response);
+            Assert.Equal(errorResponseBody, httpCallResponses.Error.Data[Http.DefaultSettings.ErrorDataPrefix + "Response.Body"]);
+        }
+        
+        [Fact]
+        public async Task WithErrorResponseBodyLogging_IfStatusCodeMatchesOneOfTheGiven_IncludeResponseBodyInException()
+        {
+            const string errorResponseBody = "{'Foo': 'Bar'}";
+            _stubHttp.Stub(x => x.Get("/some-endpoint"))
+                .Return(errorResponseBody)
+                .WithStatus(HttpStatusCode.UnprocessableEntity);
+
+            var response = await Http
+                .Request("http://localhost:9191/some-endpoint")
+                .WithErrorResponseBodyLogging(HttpStatusCode.NotAcceptable, HttpStatusCode.UnprocessableEntity)
+                .ExpectString()
+                .GetAsync();
+
+            Assert.Equal(HttpStatusCode.UnprocessableEntity,response.StatusCode);
+            
+            var httpCallResponses = Assert.IsType<HttpCallResponse<string>>(response);
+            Assert.Equal(errorResponseBody, httpCallResponses.Error.Data[Http.DefaultSettings.ErrorDataPrefix + "Response.Body"]);
+        }
+        
+        [Fact]
+        public async Task WithErrorResponseBodyLogging_IfStatusCodeDoesNotMatchAnyOfTheGiven_DoesNotIncludeResponseBodyInException()
+        {
+            const string errorResponseBody = "{'Foo': 'Bar'}";
+            _stubHttp.Stub(x => x.Get("/some-endpoint"))
+                .Return(errorResponseBody)
+                .WithStatus(HttpStatusCode.UnprocessableEntity);
+
+            var response = await Http
+                .Request("http://localhost:9191/some-endpoint")
+                .WithErrorResponseBodyLogging(HttpStatusCode.NotAcceptable, HttpStatusCode.BadRequest)
+                .ExpectString()
+                .GetAsync();
+
+            Assert.Equal(HttpStatusCode.UnprocessableEntity,response.StatusCode);
+            
+            var httpCallResponses = Assert.IsType<HttpCallResponse<string>>(response);
+            Assert.Null(httpCallResponses.Error.Data[Http.DefaultSettings.ErrorDataPrefix + "Response.Body"]);
+        }
+
+        [Fact]
+        public async Task WithErrorResponseBodyLogging_IfNoStatusCodesGiven_DoesNotIncludeResponseBodyInException()
+        {
+            const string errorResponseBody = "{'Foo': 'Bar'}";
+            _stubHttp.Stub(x => x.Get("/some-endpoint"))
+                .Return(errorResponseBody)
+                .WithStatus(HttpStatusCode.UnprocessableEntity);
+
+            var response = await Http
+                .Request("http://localhost:9191/some-endpoint")
+                .WithErrorResponseBodyLogging()
+                .ExpectString()
+                .GetAsync();
+
+            Assert.Equal(HttpStatusCode.UnprocessableEntity,response.StatusCode);
+            
+            var httpCallResponses = Assert.IsType<HttpCallResponse<string>>(response);
+            Assert.Null(httpCallResponses.Error.Data[Http.DefaultSettings.ErrorDataPrefix + "Response.Body"]);
+        }
+        
+        [Fact]
+        public async Task WithErrorResponseBodyLogging_WithoutCallingWithErrorResponseBodyLogging_DoesNotIncludeResponseBodyInException()
+        {
+            const string errorResponseBody = "{'Foo': 'Bar'}";
+            _stubHttp.Stub(x => x.Get("/some-endpoint"))
+                .Return(errorResponseBody)
+                .WithStatus(HttpStatusCode.UnprocessableEntity);
+
+            var response = await Http
+                .Request("http://localhost:9191/some-endpoint")
+                .ExpectString()
+                .GetAsync();
+
+            Assert.Equal(HttpStatusCode.UnprocessableEntity,response.StatusCode);
+            
+            var httpCallResponses = Assert.IsType<HttpCallResponse<string>>(response);
+            Assert.Null(httpCallResponses.Error.Data[Http.DefaultSettings.ErrorDataPrefix + "Response.Body"]);
+        }
+    }
+}

--- a/tests/StackExchange.Utils.Tests/StackExchange.Utils.Tests.csproj
+++ b/tests/StackExchange.Utils.Tests/StackExchange.Utils.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="HttpMock" Version="2.3.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <ProjectReference Include="../../src/StackExchange.Utils.Http/StackExchange.Utils.Http.csproj" />


### PR DESCRIPTION
# Current limitation
Right now the library doesn't support logging the response body of an error response. This makes it difficult for monitoring/debugging/troubleshooting. 

# Current workaround
```csharp
var strResponse = await Http
      .Request("http://example.com")
      // don't log 403's as errors so we can get the details out of the response body
      .WithoutLogging(HttpStatusCode.Forbidden)
      .ExpectString()
      .GetAsync();

if (!strResponse.Success)
{
 // log 
}
else
{
// deserialize
}
```

# Proposed solution
Add extension modifier method that allows you to log error response bodies for given status codes as exception data.
```csharp
  var response = await Http
      .Request("http://example.com")
      .WithErrorResponseBodyLogging(HttpStatusCode.Forbidden)
      .ExpectJson<SomeResponseObject>()
      .GetAsync();
```

# Open questions
* I am reading the response content stream outside of a handler method. Is there a possibility where this could happen twice?
* Is the [httpmock](https://github.com/hibri/HttpMock) dep okay to use for unit testing?