### PR TITLE
Fix #23 by using `ThreadLocal` instead of `AsyncLocal`

### DIFF
--- a/src/StackExchange.Utils.Configuration/SubstitutionHelper.cs
+++ b/src/StackExchange.Utils.Configuration/SubstitutionHelper.cs
@@ -14,11 +14,11 @@ namespace StackExchange.Utils
     {
         // matches a key wrapped in braces and prefixed with a '$' 
         // e.g. ${Key} or ${Section:Key} or ${Section:NestedSection:Key}
-        private static readonly Regex _substitutionPattern = new Regex(
+        private static readonly Regex _substitutionPattern = new(
             @"\$\{(?<key>[^\s]+?)\}", RegexOptions.Compiled
         );
-
-        private static readonly AsyncLocal<ICycleDetector> _cycleDetector = new AsyncLocal<ICycleDetector>();
+        
+        private static readonly ThreadLocal<ICycleDetector> _cycleDetector = new();
 
         /// <summary>
         /// Replaces substitution placeholders in a value from configuration
@@ -137,7 +137,7 @@ namespace StackExchange.Utils
         
         private class CycleDetector : ICycleDetector
         {
-            private readonly HashSet<string> _values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            private readonly HashSet<string> _values = new(StringComparer.OrdinalIgnoreCase);
 
             public void Add(string key) => _values.Add(key);
 


### PR DESCRIPTION
If the `SubstitutionHelper`was accessed on a particular async context then the `ICycleDetector` would be propagated to any subsequent async contexts initiated from that first one. `CycleDetector` uses a `HashSet` which would then be accessed concurrently and explode. This was particularly noticeable in Kestrel where the thread that initiated the `WebHost` would access a substituted configuration value, initialise the `ICycleDetector` and then each request thread would then inherit that instance.

Originally the intent was that there'd be only a single `CycleDetector` per thread so this fixes the issue by using a `ThreadLocal` instead. This ensures the cycle detection continues to work but without the concurrency issues that arise from the `AsyncLocal` being inadvertently shared across async contexts.

This commit also does some rudimentary clean-up (`new()` syntax).