### PR TITLE
Implement SendFormUrlEncoded method for application/x-www-form-urlencoded form data

### DIFF
--- a/src/StackExchange.Utils.Http/Extensions.Send.cs
+++ b/src/StackExchange.Utils.Http/Extensions.Send.cs
@@ -24,7 +24,8 @@ namespace StackExchange.Utils
         }
 
         /// <summary>
-        /// Adds a <see cref="NameValueCollection"/> as the body for this request.
+        /// Adds a <see cref="NameValueCollection"/> as the body for this request, with a content type of
+        /// <c>multipart/form-data</c>.
         /// </summary>
         /// <param name="builder">The builder we're working on.</param>
         /// <param name="form">The <see cref="NameValueCollection"/> (e.g. FormCollection) to use.</param>
@@ -38,7 +39,17 @@ namespace StackExchange.Utils
             }
             return SendContent(builder, content);
         }
-            
+
+        /// <summary>
+        /// Adds a <see cref="NameValueCollection"/> as the body for this request, with a content type of
+        /// <c>application/x-www-form-urlencoded</c>.
+        /// </summary>
+        /// <param name="builder">The builder we're working on.</param>
+        /// <param name="form">The <see cref="NameValueCollection"/> (e.g. FormCollection) to use.</param>
+        /// <returns>The request builder for chaining.</returns>
+        public static IRequestBuilder SendFormUrlEncoded(this IRequestBuilder builder, NameValueCollection form) =>
+            SendContent(builder, new FormUrlEncodedContent(form.AllKeys.ToDictionary(k => k, v => form[v])));
+
         /// <summary>
         /// Adds raw HTML content as the body for this request.
         /// </summary>


### PR DESCRIPTION
In #9, the `SendForm` extension method was changed from sending a `application/x-www-form-urlencoded` request to sending one as `multipart/form-data` instead. This is a breaking change in some cases if sending to an endpoint that doesn't expect form data to come in with `multipart/form-data` encoding (OIDC access token requests for example, see https://github.com/opserver/Opserver/pull/426).

This PR re-adds the old behaviour as a new extension method so consuming libraries don't need to add it back themselves.

I expect `application/x-www-form-urlencoded` is the more common media type that consumers will want (when size limitations or file uploads aren't a concern), but I didn't want to revert `SendForm` back to its original behaviour to avoid breaking dependent projects again.

I could also obsolete `SendForm` and provide `SendMultipartForm` / `SendFormUrlEncoded` but I don't think it's important enough to inconvenience consumers with changing their code (and getting build errors using `TreatWarningsAsErrors`).